### PR TITLE
feat: enhance auto-refresh configuration with validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the "claude-usage-monitor" extension will be documented in this file.
 
+## [2.3.5] - 2025-11-03
+
+### Improved
+- **Enhanced Auto-Refresh Configuration**: Added validation and range constraints to refresh interval setting
+  - Enforced 1-60 minute valid range with JSON schema constraints (`minimum` and `maximum`)
+  - Added runtime validation to clamp values within valid range
+  - Updated setting description to clearly indicate valid range
+  - Prevents invalid configuration values from breaking the extension
+
+### Changed
+- Updated README.md to reflect accurate configuration defaults and valid ranges
+- Cleaned up documentation references to removed activity-based refresh feature
+- Improved configuration examples with clearer guidance
+
 ## [2.3.0] - 2025-10-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Monitor your Claude.ai chat usage directly in VS Code. This extension uses direc
   - Color-coded indicators for both metrics
 - **Status Bar Integration**: See both percentages at a glance (e.g., "Claude: 45% | Tokens: 26%")
 - **Tree View Panel**: Detailed usage information in a dedicated side panel
-- **Fixed 5-Minute Refresh**: Simple, reliable refresh every 5 minutes
+- **Configurable Auto-Refresh**: Customizable refresh interval (1-60 minutes, default 5 minutes)
 - **Usage Level Indicator**: Shows how much "Claude time" remains (Idle/Light/Moderate/Heavy)
   - Based on max of Claude.ai usage % or session token %
   - Idle (0-24%): Plenty of Claude time! | Light (25-49%): Quarter+ used
@@ -57,9 +57,9 @@ The extension will **automatically fetch usage data** when VS Code starts. If yo
 
 **That's it!** The extension will now:
 - Fetch usage automatically on startup
-- Refresh every 5 minutes (configurable)
+- Refresh at your configured interval (default: every 5 minutes, range: 1-60 minutes)
 - Display both Claude.ai and session token usage
-- Show your coding activity level
+- Show your usage level
 - Run completely hidden unless login is required
 
 ## Usage
@@ -85,7 +85,7 @@ There are several ways to fetch your usage data:
     - Usage percentage
     - Reset time
     - Last update timestamp
-    - **Activity level and next refresh interval** (e.g., "Heavy (5 min refresh)")
+    - Usage level (Idle/Light/Moderate/Heavy)
 
 - **Tree View Panel**: Shows detailed information:
   - Usage percentage
@@ -106,32 +106,27 @@ Open VS Code Settings and search for "Claude Usage" to configure:
 - **Default**: `true` ✅
 - **Description**: Run browser in headless (hidden) mode. Browser will show automatically if login is needed.
 
-### `claudeUsage.activityBasedRefresh` 🆕
-- **Type**: Boolean
-- **Default**: `true` ✅
-- **Description**: Automatically adjust refresh rate based on coding activity (5-60 minutes). Disable to use fixed interval.
-
 ### `claudeUsage.autoRefreshMinutes`
 - **Type**: Number
-- **Default**: `15`
-- **Description**: Fixed auto-refresh interval in minutes (only used when Activity-Based Refresh is disabled)
+- **Default**: `5`
+- **Range**: `1-60` minutes
+- **Description**: Auto-refresh interval in minutes for checking Claude.ai usage and session token data
 
 **Recommended Configuration** (`settings.json`):
 ```json
 {
   "claudeUsage.fetchOnStartup": true,
   "claudeUsage.headless": true,
-  "claudeUsage.activityBasedRefresh": true
+  "claudeUsage.autoRefreshMinutes": 5
 }
 ```
 
-**For Fixed Interval Instead** (`settings.json`):
+**Example: Custom Refresh Interval** (`settings.json`):
 ```json
 {
   "claudeUsage.fetchOnStartup": true,
   "claudeUsage.headless": true,
-  "claudeUsage.activityBasedRefresh": false,
-  "claudeUsage.autoRefreshMinutes": 30
+  "claudeUsage.autoRefreshMinutes": 15
 }
 ```
 
@@ -144,15 +139,12 @@ All commands are available via the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+
 
 ## How It Works
 
-### Smart Activity Detection
-The extension monitors your VS Code activity to optimize refresh timing:
-- Tracks text edits, file saves, and editor changes
-- Calculates activity level every 15 minutes
-- Adjusts refresh rate automatically:
-  - **Heavy coding**: 5-minute intervals
-  - **Moderate work**: 15-minute intervals
-  - **Light activity**: 30-minute intervals
-  - **Idle/break**: 60-minute intervals
+### Automatic Refresh
+The extension automatically refreshes usage data at configurable intervals:
+- Default: Every 5 minutes
+- Customizable: 1-60 minute range
+- Updates both Claude.ai usage and session token data
+- Runs silently in the background
 
 ### Headless Browser Operation
 1. The extension uses Puppeteer to launch a Chromium browser
@@ -221,9 +213,8 @@ The extension monitors your VS Code activity to optimize refresh timing:
 
 **Solutions**:
 - `headless` mode is enabled by default - browser runs hidden
-- Activity-based refresh automatically reduces frequency when idle
 - The browser closes automatically after fetching to save memory
-- If using fixed interval, increase `autoRefreshMinutes` to reduce frequency
+- Increase `autoRefreshMinutes` to reduce refresh frequency (e.g., 15, 30, or 60 minutes)
 
 ## Known Limitations
 

--- a/extension.js
+++ b/extension.js
@@ -235,8 +235,11 @@ async function activate(context) {
         }, 2000); // Wait 2 seconds after activation
     }
 
-    // Set up fixed 5-minute interval for usage checks
-    const autoRefreshMinutes = config.get('autoRefreshMinutes', 5);
+    // Set up auto-refresh interval for usage checks
+    let autoRefreshMinutes = config.get('autoRefreshMinutes', 5);
+    // Validate and clamp to 1-60 minute range
+    autoRefreshMinutes = Math.max(1, Math.min(60, autoRefreshMinutes));
+
     if (autoRefreshMinutes > 0) {
         autoRefreshTimer = setInterval(async () => {
             try {
@@ -262,7 +265,9 @@ async function activate(context) {
 
                 // Restart with new configuration
                 const newConfig = vscode.workspace.getConfiguration('claudeUsage');
-                const newAutoRefresh = newConfig.get('autoRefreshMinutes', 5);
+                let newAutoRefresh = newConfig.get('autoRefreshMinutes', 5);
+                // Validate and clamp to 1-60 minute range
+                newAutoRefresh = Math.max(1, Math.min(60, newAutoRefresh));
 
                 if (newAutoRefresh > 0) {
                     autoRefreshTimer = setInterval(async () => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-session-usage",
   "displayName": "Claude Session Usage",
   "description": "Monitor your Claude.ai usage directly in VS Code with fast API access and session tracking",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "publisher": "Gronsten",
   "author": {
     "name": "Mark Campbell",
@@ -79,7 +79,9 @@
         "claudeUsage.autoRefreshMinutes": {
           "type": "number",
           "default": 5,
-          "description": "Auto-refresh interval in minutes for checking Claude.ai usage and session token data"
+          "minimum": 1,
+          "maximum": 60,
+          "description": "Auto-refresh interval in minutes for checking Claude.ai usage and session token data (1-60 minutes)"
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add JSON schema validation (minimum: 1, maximum: 60) to autoRefreshMinutes setting
- Implement runtime value clamping to enforce 1-60 minute range  
- Update setting description to clearly indicate valid range
- Fix README documentation with correct default value (5 minutes)
- Remove outdated activity-based refresh references from documentation
- Bump version to 2.3.5

## Changes Made

### Configuration Enhancement
- Added `minimum: 1` and `maximum: 60` JSON schema constraints to `claudeUsage.autoRefreshMinutes`
- Implemented runtime validation using `Math.max(1, Math.min(60, value))` clamping
- Applied validation to both initial load and configuration change events

### Documentation Improvements
- Updated README.md with accurate default value (was 15, now correctly shows 5)
- Clarified valid range (1-60 minutes) in setting description and README
- Removed references to deprecated activity-based refresh feature
- Improved configuration examples with clearer guidance

### Version & Changelog
- Bumped package.json version from 2.3.4 to 2.3.5
- Added comprehensive CHANGELOG.md entry for v2.3.5

## Benefits
- **Better UX**: Users see valid range constraints in VS Code settings UI
- **Error Prevention**: Invalid values are automatically corrected at runtime
- **Clear Documentation**: Users understand exactly what values are acceptable
- **Backwards Compatible**: Existing configurations continue to work

## Test Plan
- [x] Verified JSON schema constraints appear in VS Code settings UI
- [x] Tested runtime clamping with values below 1 (clamped to 1)
- [x] Tested runtime clamping with values above 60 (clamped to 60)
- [x] Confirmed configuration change listener updates timer correctly
- [x] Verified documentation accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)