### PR TITLE
Add GitHub Sponsors integration and visual enhancements (v2.3.9)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub Sponsors configuration
+github: Gronsten

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the "claude-usage-monitor" extension will be documented in this file.
 
+## [2.3.9] - 2025-11-17
+
+### Added
+- **GitHub Sponsors Integration**: Added sponsor support across the extension
+  - Added `.github/FUNDING.yml` for automatic sponsor button on GitHub repo
+  - Added sponsor badge to README (social style badge at top)
+  - Added `sponsor` field to package.json for VS Code Marketplace sponsor button
+
+### Documentation
+- **README Visual Enhancements**: Improved README presentation with modern features
+  - Added colorful GitHub alert callouts (TIP and NOTE boxes)
+  - TIP box highlights v2.3.8 screenshots feature
+  - NOTE box explains dual monitoring capability (web + Claude Code)
+  - Added Demo section with placeholder for future demo.gif
+  - Created `assets/` directory with instructions for demo GIF creation
+  - Enhanced visibility of key features and extension capabilities
+
 ## [2.3.8] - 2025-11-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Claude Usage Monitor
 
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/Gronsten?style=social)](https://github.com/sponsors/Gronsten)
+
 Monitor your Claude usage from both Claude.ai web client and Claude Code sessions directly in VS Code. This extension tracks web usage via direct API access (with intelligent fallback to web scraping) and monitors Claude Code token consumption through intelligent session tracking that automatically detects usage from your active conversation, even when multiple conversations are open.
+
+> [!TIP]
+> **NEW in v2.3.8:** Professional screenshots added to marketplace listing showcasing status bar integration, detailed tooltips, tree view panel, and configuration settings!
+
+> [!NOTE]
+> **Dual Monitoring:** This extension tracks BOTH Claude.ai web usage (5-hour and 7-day limits) AND your Claude Code session token consumption in real-time with intelligent session detection.
+
+## Demo
+
+![Demo](assets/demo.gif)
+
+*See the extension in action: automatic usage fetching, status bar updates, and detailed usage breakdowns*
 
 ## Screenshots
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,49 @@
+# Assets Directory
+
+## Creating demo.gif
+
+To create a demo GIF for the README:
+
+1. **Recording Tools:**
+   - Windows: Use [ScreenToGif](https://www.screentogif.com/) (free, open-source)
+   - Alternative: [LICEcap](https://www.cockos.com/licecap/) (cross-platform)
+   - VS Code specific: [GIF Recorder](https://marketplace.visualstudio.com/items?itemName=idered.gif-recorder) extension
+
+2. **What to Record:**
+   - Fresh VS Code start showing auto-fetch on startup
+   - Status bar showing usage percentages
+   - Hover tooltip with detailed information
+   - Click to manually refresh
+   - Open tree view panel from activity bar
+   - Show color changes at different usage levels
+   - Keep recording under 30 seconds for optimal file size
+
+3. **Recording Settings:**
+   - Frame rate: 10-15 FPS (sufficient for UI demos)
+   - Resolution: 800px width minimum (readable on GitHub)
+   - Duration: 20-30 seconds (keeps file size manageable)
+   - File size target: Under 5MB for GitHub
+
+4. **Save the file:**
+   - Save as `demo.gif` in this directory
+   - GitHub automatically displays it in the README
+
+## Tips for Great Demo GIFs
+
+- Use a clean VS Code theme (Dark+ or Light+ for consistency)
+- Zoom in on the status bar and tree view for visibility
+- Move cursor deliberately (not too fast)
+- Show 2-3 key features in sequence
+- Add brief pauses between actions (1-2 seconds)
+- Demonstrate the color-coded warnings (green → orange → red)
+- Optimize GIF size with tools like [gifsicle](https://www.lcdf.org/gifsicle/)
+
+## Demo Sequence Suggestion
+
+1. Show VS Code startup (2 sec)
+2. Status bar appears with usage (2 sec)
+3. Hover over status bar for tooltip (3 sec)
+4. Click status bar to refresh (3 sec)
+5. Open activity bar panel (2 sec)
+6. Show detailed usage info in panel (3 sec)
+7. Navigate through tree view items (3 sec)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-session-usage",
   "displayName": "Claude Session Usage",
   "description": "Monitor Claude.ai web usage and Claude Code token consumption directly in VS Code with real-time tracking",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "publisher": "Gronsten",
   "author": {
     "name": "Mark Campbell",
@@ -18,6 +18,9 @@
   "homepage": "https://github.com/Gronsten/claude-usage-monitor#readme",
   "license": "MIT",
   "icon": "icons/claude-usage-icon.png",
+  "sponsor": {
+    "url": "https://github.com/sponsors/Gronsten"
+  },
   "engines": {
     "vscode": "^1.80.0"
   },


### PR DESCRIPTION
## Summary

Enhanced GitHub repository presence and VS Code Marketplace listing with sponsor support and improved README presentation.

## Changes

### GitHub Sponsors Integration
- ✅ Added `.github/FUNDING.yml` for automatic sponsor button on GitHub repo page
- ✅ Added sponsor badge to README (social style badge at top)
- ✅ Added `sponsor` field to package.json for VS Code Marketplace sponsor button

### README Visual Enhancements
- ✅ Added colorful GitHub alert callouts (TIP and NOTE boxes)
  - TIP box highlights v2.3.8 screenshots feature
  - NOTE box explains dual monitoring capability (web + Claude Code)
- ✅ Added Demo section with placeholder for future demo.gif
- ✅ Created `assets/` directory with instructional README for demo GIF creation

### Version Management
- ✅ Bumped version to 2.3.9 in package.json
- ✅ Added v2.3.9 entry to CHANGELOG.md

## Testing Notes

- [x] Verified package.json has valid sponsor field format
- [x] Confirmed version updated to 2.3.9
- [x] Checked README markdown renders correctly locally
- [x] Confirmed all files staged and committed

## User Impact

### GitHub
- Users will see sponsor button on GitHub repo page automatically
- Improved README presentation with modern GitHub features
- Better visibility of key features and dual monitoring capability

### VS Code Marketplace
- **Sponsor button will appear in marketplace listing** (after republish)
- Users can easily support the extension development
- Enhanced README visible on marketplace page

## Next Steps

- After merge: Create GitHub release v2.3.9
- After merge: Republish to VS Code Marketplace with `vsce publish`
- Future: Create demo.gif following instructions in `assets/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)