### PR TITLE
Update documentation to use npm scripts instead of direct vsce commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -945,7 +945,7 @@ vscode.workspace.onDidChangeConfiguration(e => {
 - Added: New feature description
 
 # 3. Package the extension
-vsce package
+npm run package
 
 # 4. Move old .vsix to archive
 mv claude-session-usage-2.3.9.vsix archive/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ After packaging a new .vsix version, **ALWAYS** move the old .vsix files to the 
 
 ### Commands
 ```bash
-# Package new version
-vsce package
+# Build and package new version
+npm run package
 
 # Move old versions to archive
 mv *.vsix archive/  # Move all but keep the latest one out
@@ -39,7 +39,7 @@ claude-usage/
 1. Make changes and test
 2. Update version in package.json
 3. Update CHANGELOG.md
-4. Run `vsce package`
+4. Run `npm run package` (builds with esbuild + packages)
 5. **Move previous .vsix file(s) to archive/**
 6. Test the new .vsix installation
 7. Commit and push changes

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -74,13 +74,13 @@ Press `Ctrl+,` to open settings and search for "Claude Usage":
 
 ### Install VSCE (VS Code Extension Manager)
 ```bash
-npm install -g @vscode/vsce
+npm install -g @vscode/vsce  # Only needed for manual vsce commands
 ```
 
 ### Create VSIX Package
 ```bash
 cd vscode-extensions/claude-usage
-vsce package
+npm run package
 ```
 
 This creates `claude-usage-monitor-1.0.0.vsix`
@@ -109,10 +109,10 @@ This creates `claude-usage-monitor-1.0.0.vsix`
 npm install
 
 # Package extension
-vsce package
+npm run package
 
 # Publish to marketplace (requires publisher account)
-vsce publish
+npm run publish
 ```
 
 ## 🎯 Key Files Explained

--- a/TESTING.md
+++ b/TESTING.md
@@ -189,16 +189,15 @@ Before considering the extension ready:
 - [ ] Error messages are user-friendly
 - [ ] Documentation matches actual behavior
 - [ ] Configuration options all work correctly
-- [ ] Extension can be packaged: `vsce package` (if vsce installed)
+- [ ] Extension can be packaged: `npm run package`
 
 ## Packaging Test
 
-If you have `vsce` installed:
+Package the extension using the npm script:
 
 ```bash
-npm install -g @vscode/vsce
 cd claude-usage
-vsce package
+npm run package
 ```
 
 - [ ] Package creates successfully (creates .vsix file)


### PR DESCRIPTION
## Summary

This PR updates all documentation files to reference the new npm script commands (, ) instead of direct vsce commands, reflecting the esbuild bundling workflow introduced in v2.5.0.

### Changes

- **ARCHITECTURE.md**: Updated release workflow section
- **CLAUDE.md**: Updated packaging commands and workflow checklist  
- **QUICKSTART.md**: Updated packaging and publishing commands
- **TESTING.md**: Updated packaging test instructions

### Before


### After


### Why

With v2.5.0, the extension now uses esbuild bundling. The npm scripts handle both building (with esbuild) and packaging/publishing in one command. Direct  commands would skip the build step and package unbundled code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)