### PR TITLE
Bump version to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-session-usage",
   "displayName": "Claude Session Usage",
   "description": "Monitor Claude.ai web usage and Claude Code token consumption directly in VS Code with real-time tracking",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "publisher": "Gronsten",
   "author": {
     "name": "Mark Campbell",


### PR DESCRIPTION
## Summary
Bump version to 2.5.1 for demo.gif release

## Changes
- Updated package.json version: 2.5.0 → 2.5.1
- Added CHANGELOG.md entry for v2.5.1
- Documented demo.gif addition and placeholder README removal

## Version History
- v2.5.0: esbuild bundling
- v2.5.1: Demo GIF addition (this release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)